### PR TITLE
Save plot to disk

### DIFF
--- a/DeepScence/io.py
+++ b/DeepScence/io.py
@@ -293,5 +293,6 @@ def binarize_adata(adata, verbose=True):
 
     plt.tight_layout()
     plt.show()
+    plt.savefig('deepscence.pdf')
 
     return adata


### PR DESCRIPTION
We are running DeepScence as part of our RNA-seq pipeline, and we need to save the plot to disk to actually view it. I believe it would be helpful for other folks using the tool to save the plot as well.